### PR TITLE
Refactor unittest framework

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ We chose to use [Ruff](https://docs.astral.sh/ruff/) to automatically lint and f
 >
 > 
 > ```sh
-> ruff format . && ruff check --include I --fix . # this formats code and sort imports
+> ruff format . && ruff check --select I --fix . # this formats code and sort imports
 > ruff check . # run linting and perform fixes
 > mypy main.py
 > ```
@@ -193,7 +193,7 @@ We chose to use [Ruff](https://docs.astral.sh/ruff/) to automatically lint and f
 >
 > ```powershell
 > ruff format .;
-> ruff check --include I --fix .;
+> ruff check --select I --fix .;
 > ruff check .;
 > mypy main.py
 > ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,12 @@ explicit_package_bases = true
 
 ["mypy-pygame.*"]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+# -ra: Show extra test summary info for all tests.
+# -q: Quiet mode, which reduces the verbosity of the output.
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+]

--- a/src/sprites/gui/inventory_gui.py
+++ b/src/sprites/gui/inventory_gui.py
@@ -117,7 +117,6 @@ class InventoryGUI:
         # Reset button actions
         self.button_actions: dict[str, tuple[pygame.Rect, pygame.Rect]] = {}
 
-
         # Draw the inventory items
         items: list = list(self.inventory.get_items().items())
         visible_items: list = items[self.scroll_offset : self.scroll_offset + self.max_visible_items]

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -16,10 +16,12 @@ from src.utils.messaging import get_message
 #         """Set up a new Inventory object before each test."""
 #         self.inventory = Inventory()
 
+
 @pytest.fixture
 def inventory():
     """Set up a new Inventory object before each test."""
     return Inventory()
+
 
 # Test add_item
 def test_add_item_new(inventory):
@@ -29,12 +31,14 @@ def test_add_item_new(inventory):
     assert inventory.items == {"Sword": 1}
     assert result == expected
 
+
 def test_add_item_existing(inventory):
     """Test adding to an existing item."""
     result = inventory.add_item("Potion", 2)
     expected = get_message("inventory", "add_success", item="Potion", quantity=2)
     assert inventory.items == {"Potion": 2}
     assert result == expected
+
 
 # Test remove_item
 def test_remove_item_success(inventory):
@@ -53,6 +57,7 @@ def test_remove_item_fail(inventory):
     assert inventory.items == {}
     assert result == expected
 
+
 # Test use_item
 def test_use_item_success(inventory):
     """Test using an item."""
@@ -62,12 +67,14 @@ def test_use_item_success(inventory):
     assert inventory.items == {}
     assert result == expected
 
+
 def test_use_item_fail(inventory):
     """Test failing to use an item."""
     result = inventory.use_item("Potion")
     expected = get_message("inventory", "use_fail", item="Potion")
     assert inventory.items == {}
     assert result == expected
+
 
 # Test add_chest
 def test_add_chest(inventory):
@@ -77,13 +84,15 @@ def test_add_chest(inventory):
     assert len(inventory.chests) == 1
     assert inventory.chests[0].name == "Gold Chest"
 
+
 # Test add_quest
 def test_add_quest(inventory):
     """Test adding a quest."""
     quest = Quest()
     inventory.add_quest(quest)
     assert len(inventory.quests) == 1
-    assert inventory.quests[0].completed == False
+    assert not inventory.quests[0].completed
+
 
 # Test get_items
 def test_get_items(inventory):
@@ -92,6 +101,7 @@ def test_get_items(inventory):
     items = inventory.get_items()
     assert items == {"Sword": 1}
     assert items is not inventory.items  # Copy of items
+
 
 # Test get_chests
 def test_get_chests(inventory):
@@ -102,6 +112,7 @@ def test_get_chests(inventory):
     assert len(chests) == 1
     assert chests[0].name == "Gold Chest"
     assert chests is not inventory.chests  # Copy of items
+
 
 # Test get_quests
 def test_get_quests(inventory):

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -4,100 +4,110 @@ import sys
 # Add the project root to sys.path to allow imports to work when running tests directly with `python`.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import unittest
+
+import pytest
 
 from src.inventory import Chest, Inventory, Quest
+from src.utils.messaging import get_message
+
+# Old way of writing tests using unittest
+# class TestInventory(unittest.TestCase):
+#     def setUp(self):
+#         """Set up a new Inventory object before each test."""
+#         self.inventory = Inventory()
+
+@pytest.fixture
+def inventory():
+    """Set up a new Inventory object before each test."""
+    return Inventory()
+
+# Test add_item
+def test_add_item_new(inventory):
+    """Test adding a new item."""
+    result = inventory.add_item("Sword", 1)
+    expected = get_message("inventory", "add_success", item="Sword", quantity=1)
+    assert inventory.items == {"Sword": 1}
+    assert result == expected
+
+def test_add_item_existing(inventory):
+    """Test adding to an existing item."""
+    result = inventory.add_item("Potion", 2)
+    expected = get_message("inventory", "add_success", item="Potion", quantity=2)
+    assert inventory.items == {"Potion": 2}
+    assert result == expected
+
+# Test remove_item
+def test_remove_item_success(inventory):
+    """Test successfully removing an item."""
+    inventory.add_item("Potion", 3)
+    result = inventory.remove_item("Potion", 2)
+    expected = get_message("inventory", "remove_success", item="Potion", quantity=2)
+    assert inventory.items == {"Potion": 1}
+    assert result == expected
 
 
-class TestInventory(unittest.TestCase):
-    def setUp(self):
-        """Set up a new Inventory object before each test."""
-        self.inventory = Inventory()
+def test_remove_item_fail(inventory):
+    """Test failing to remove an item not in inventory or insufficient quantity."""
+    result = inventory.remove_item("Sword", 1)
+    expected = get_message("inventory", "remove_fail", item="Sword", quantity=1)
+    assert inventory.items == {}
+    assert result == expected
 
-    # Test add_item
-    def test_add_item_new(self):
-        """Test adding a new item."""
-        result = self.inventory.add_item("Sword", 1)
-        self.assertEqual(self.inventory.items, {"Sword": 1})
-        self.assertEqual(result, "Successfully added 1 Sword(s) to your inventory.")
+# Test use_item
+def test_use_item_success(inventory):
+    """Test using an item."""
+    inventory.add_item("Potion", 1)
+    result = inventory.use_item("Potion")
+    expected = get_message("inventory", "use_success", item="Potion")
+    assert inventory.items == {}
+    assert result == expected
 
-    def test_add_item_existing(self):
-        """Test adding to an existing item."""
-        self.inventory.add_item("Potion", 1)
-        result = self.inventory.add_item("Potion", 2)
-        self.assertEqual(self.inventory.items, {"Potion": 3})
-        self.assertEqual(result, "Successfully added 2 Potion(s) to your inventory.")
+def test_use_item_fail(inventory):
+    """Test failing to use an item."""
+    result = inventory.use_item("Potion")
+    expected = get_message("inventory", "use_fail", item="Potion")
+    assert inventory.items == {}
+    assert result == expected
 
-    # Test remove_item
-    def test_remove_item_success(self):
-        """Test successfully removing an item."""
-        self.inventory.add_item("Potion", 3)
-        result = self.inventory.remove_item("Potion", 2)
-        self.assertEqual(self.inventory.items, {"Potion": 1})
-        self.assertEqual(result, "Successfully removed 2 Potion(s) from your inventory.")
+# Test add_chest
+def test_add_chest(inventory):
+    """Test adding a chest."""
+    chest = Chest("Gold Chest")
+    inventory.add_chest(chest)
+    assert len(inventory.chests) == 1
+    assert inventory.chests[0].name == "Gold Chest"
 
-    def test_remove_item_fail(self):
-        """Test failing to remove an item not in inventory or insufficient quantity."""
-        result = self.inventory.remove_item("Sword", 1)
-        self.assertEqual(self.inventory.items, {})
-        self.assertEqual(result, "Cannot remove 1 Sword(s), insufficient quantity.")
+# Test add_quest
+def test_add_quest(inventory):
+    """Test adding a quest."""
+    quest = Quest()
+    inventory.add_quest(quest)
+    assert len(inventory.quests) == 1
+    assert inventory.quests[0].completed == False
 
-    # Test use_item
-    def test_use_item_success(self):
-        """Test using an item."""
-        self.inventory.add_item("Potion", 1)
-        result = self.inventory.use_item("Potion")
-        self.assertEqual(self.inventory.items, {})
-        self.assertEqual(result, "You used Potion.")
+# Test get_items
+def test_get_items(inventory):
+    """Test getting a copy of items."""
+    inventory.add_item("Sword", 1)
+    items = inventory.get_items()
+    assert items == {"Sword": 1}
+    assert items is not inventory.items  # Copy of items
 
-    def test_use_item_fail(self):
-        """Test failing to use an item."""
-        result = self.inventory.use_item("Potion")
-        self.assertEqual(self.inventory.items, {})
-        self.assertEqual(result, "You dont' have Potion in your inventory.")
+# Test get_chests
+def test_get_chests(inventory):
+    """Test getting a copy of chests."""
+    chest = Chest("Gold Chest")
+    inventory.add_chest(chest)
+    chests = inventory.get_chests()
+    assert len(chests) == 1
+    assert chests[0].name == "Gold Chest"
+    assert chests is not inventory.chests  # Copy of items
 
-    # Test add_chest
-    def test_add_chest(self):
-        """Test adding a chest."""
-        chest = Chest("Gold Chest")
-        self.inventory.add_chest(chest)
-        self.assertEqual(len(self.inventory.chests), 1)
-        self.assertEqual(self.inventory.chests[0].name, "Gold Chest")
-
-    # Test add_quest
-    def test_add_quest(self):
-        """Test adding a quest."""
-        quest = Quest()
-        self.inventory.add_quest(quest)
-        self.assertEqual(len(self.inventory.quests), 1)
-        self.assertFalse(self.inventory.quests[0].completed)
-
-    # Test get_items
-    def test_get_items(self):
-        """Test getting a copy of items."""
-        self.inventory.add_item("Sword", 1)
-        items = self.inventory.get_items()
-        self.assertEqual(items, {"Sword": 1})
-        self.assertIsNot(items, self.inventory.items)  # Copy of items
-
-    # Test get_chests
-    def test_get_chests(self):
-        """Test getting a copy of chests."""
-        chest = Chest("Gold Chest")
-        self.inventory.add_chest(chest)
-        chests = self.inventory.get_chests()
-        self.assertEqual(len(chests), 1)
-        self.assertIsNot(chests, self.inventory.chests)  # Copy of items
-
-    # Test get_quests
-    def test_get_quests(self):
-        """Test getting a copy of quests."""
-        quest = Quest()
-        self.inventory.add_quest(quest)
-        quests = self.inventory.get_quests()
-        self.assertEqual(len(quests), 1)
-        self.assertIsNot(quests, self.inventory.quests)  # Copy of items
-
-
-if __name__ == "__main__":
-    unittest.main()
+# Test get_quests
+def test_get_quests(inventory):
+    """Test getting a copy of quests."""
+    quest = Quest()
+    inventory.add_quest(quest)
+    quests = inventory.get_quests()
+    assert len(quests) == 1
+    assert quests is not inventory.quests  # Copy of items


### PR DESCRIPTION
# Pull Request Template

## Type of Pull Request
Only check one box per pull request.
- [x] 🛠️ Code - Changes to the codebase.
- [ ] 🔄 Revert - Reverts a previously merged commit or PR.
- [ ] 📄 Documentation - Updates to documentation files.
- [ ] 🎵 Audio - Changes to audio files.
- [ ] 🎨 Asset - Updates to design or visual assets.

## Summary

<!-- 
INSTRUCTIONS:
- Briefly describe the purpose of this pull request. 
-->

This PR <!-- adds|modifies|updates|fixes|reverts --> ... <!-- Briefly explain what the PR changes. --> refactors the `unit test`  framework back to `pytest`, as specified in `requirements_dev.txt`. This change is useful as it simplified the creation of unit tests easier and adds additional support showing errors during testing.

The update is also needed, to integrate the [Hypothesis](https://hypothesis.readthedocs.io/en/latest/index.html) library, which employs property based testing. Useful for testing edge cases you haven't thought of. Given the ongoing movement rework, associated with issues #103 & #104 which involved libraries such as NumPy and Pathfinding, it could be very useful.

The unit test for the inventory was made by @AnSiChen, I integrated the `get_message` module in the unit test as well, this change could be better in the future if the inventory gets an overhaul, with mock testing for example, or with the use of Hypothesis to handle specific edge cases.

## Related Issues
<!-- 
INSTRUCTIONS:
- Mention related issue numbers here.
- Example: "Fixes #123, Closes #456."
-->

This PR <!-- fixes|closes|addresses|reverts --> issue(s) <!-- (e.g., Fixes #123, Closes #456) -->

---

## ✅ Checklist:

- [x] Tested the changes locally.
- [x] Verified that no breaking changes are introduced.
- [ ] Updated documentation (if applicable).


## 🏷️ Labels:
`type: ...`, `area: ...`, `game-...`, ... <!-- Fill and expand on this line as needed. See https://github.com/PyCeas/Pyceas/wiki/Guide-to-using-labels for more information. -->
